### PR TITLE
Define proto2 as the protobuf version.

### DIFF
--- a/rustplus.proto
+++ b/rustplus.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package rustplus;
 
 // This took me a while to craft by hand 😴


### PR DESCRIPTION
While using any compiled protobuf tooling it assumes proto2 and throws a
warning. This ensures that it uses proto2 and solves the warning.