### PR TITLE
Added name to map markers

### DIFF
--- a/rustplus.proto
+++ b/rustplus.proto
@@ -258,6 +258,7 @@ message AppMap {
 		required string token = 1;
 		required float x = 2;
 		required float y = 3;
+		required float name = 7;
 	}
 }
 


### PR DESCRIPTION
Adds name to Note struct

New rust update allows you to have up to 5 labels now, with colors, symbols and names.