### PR TITLE
Fix: Add WebSocket existence check before checking readyState

### DIFF
--- a/rustplus.js
+++ b/rustplus.js
@@ -125,7 +125,7 @@ class RustPlus extends EventEmitter {
      * @returns {boolean}
      */
     isConnected() {
-        return (this.websocket.readyState === WebSocket.OPEN);
+        return (this.websocket && this.websocket.readyState === WebSocket.OPEN);
     }
 
     /**


### PR DESCRIPTION
This PR adds a check to ensure that the `this.websocket` object exists before attempting to access its `readyState`. This prevents runtime errors when trying to disconnect or interact with an undefined or null WebSocket instance.

**Why this change?**
Without this change, attempting to access `this.websocket.readyState` when `this.websocket` is null or undefined will cause a runtime error. This update ensures a safer check for the WebSocket state, preventing potential crashes.

**Testing:**
Tested by simulating cases where `this.websocket` might not be defined. Verified that the program no longer crashes and behaves correctly when trying to disconnect or check WebSocket status.